### PR TITLE
Change the player design for mobile + Enable playback setting

### DIFF
--- a/client/src/assets/player/peertube-player-manager.ts
+++ b/client/src/assets/player/peertube-player-manager.ts
@@ -185,7 +185,7 @@ export class PeertubePlayerManager {
 
     // If video is audio
     if (options && options.isAudio && videojsOptions && videojsOptions.controlBar && videojsOptions.controlBar.children) {
-      videojsOptions.controlBar.children['settingsButton'].entries = [];
+      videojsOptions.controlBar.children['settingsButton'].entries = ['playbackRateMenuButton'];
       videojsOptions.controlBar.fullscreenToggle = false;
       videojsOptions.bigPlayButton = false;
       videojsOptions.inactivityTimeout = 0;

--- a/client/src/sass/player/bastyon.scss
+++ b/client/src/sass/player/bastyon.scss
@@ -467,11 +467,14 @@
             border-top-left-radius: 0 !important;
             box-shadow: none;
             // mix-blend-mode: difference;
-            background: rgba(rgb(66, 66, 66), 0.5);
+            background: rgba(rgb(66, 66, 66), 0.25);
             color: white;
         }
         .vjs-overlay{
             display: none !important;
+        }
+        .vjs-mobile-buttons-overlay {
+            display: none;
         }
     }
 
@@ -551,6 +554,21 @@ html.mobileview{
 
 html.mobileview{
     @include mobileview ();
+
+    .video-js.vjs-is-audio {
+        height: 120px;
+        .vjs-play-control{
+            display: flex;
+        }
+        .vjs-volume-control {
+            display: flex;
+        }
+        .vjs-settings-dialog {
+            position: sticky;
+            z-index: 10;
+            margin-right: 50px;
+        }
+    }
 }
 
 @media only screen and (max-width: 768px){

--- a/client/src/standalone/videos/shared/player-html.ts
+++ b/client/src/standalone/videos/shared/player-html.ts
@@ -160,6 +160,8 @@ export class PlayerHTML {
 		poster.className = "vjs-thumb video-js";
 		poster.style.backgroundImage = 'url('+url+')'
 		
+	if (videoInfo.isAudio)
+	 poster.className += " vjs-is-audio";
 
 	var aslayer = this.createARElement(videoInfo)
 		poster.appendChild(aslayer)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
- Improve the audio player design for mobile view
- Enable the playback setting
- Fix a small issue where the audio player will pause when changing time
- Lower the control bar background opacity a bit

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

Mobile:
![image](https://user-images.githubusercontent.com/3897502/213727054-d3c6d791-9d70-4777-bbfb-178d526c363e.png)

Desktop:
![image](https://user-images.githubusercontent.com/3897502/213727146-4dcee081-ddc6-4c11-8802-e2e54cba217a.png)





