### PR TITLE
Roll back the audio player style

### DIFF
--- a/client/src/sass/player/bastyon.scss
+++ b/client/src/sass/player/bastyon.scss
@@ -457,7 +457,7 @@
     }
 
     &.vjs-is-audio {
-        height: 126px;
+        // height: 126px;
         background: transparent;
         video {
             display: none;

--- a/client/src/sass/player/bastyon.scss
+++ b/client/src/sass/player/bastyon.scss
@@ -457,7 +457,7 @@
     }
 
     &.vjs-is-audio {
-        height: 200px;
+        height: 126px;
         background: transparent;
         video {
             display: none;

--- a/client/src/standalone/videos/embed.scss
+++ b/client/src/standalone/videos/embed.scss
@@ -25,7 +25,7 @@ $assets-path: '../../assets/';
 }
 
 .video-js.vjs-is-audio {
-  height: 200px;
+  height: 126px;
   // background: transparent;
   background-size: cover;
   background-position: center;

--- a/client/src/standalone/videos/embed.scss
+++ b/client/src/standalone/videos/embed.scss
@@ -25,7 +25,7 @@ $assets-path: '../../assets/';
 }
 
 .video-js.vjs-is-audio {
-  height: 126px;
+  // height: 126px;
   // background: transparent;
   background-size: cover;
   background-position: center;

--- a/client/src/standalone/videos/embed.ts
+++ b/client/src/standalone/videos/embed.ts
@@ -533,8 +533,12 @@ export class PeerTubeEmbed {
 
 				const wrapperSize = this.playerHTML.getWrapperSize();
 
-				if (!ctx || !wrapperSize)
+				var playerControl: any = this.playerHTML.getWrapperElement().getElementsByClassName('vjs-control-bar')
+
+				if (!ctx || !wrapperSize || !playerControl || playerControl.length <= 0)
 					return
+
+				playerControl = playerControl[0];
 
 				audioWallpaper.style.width = ((isPip) ? 0 : wrapperSize.height) + 'px';
 				audioWallpaper.style.height = ((isPip) ? 0 : wrapperSize.height) + 'px';
@@ -550,11 +554,19 @@ export class PeerTubeEmbed {
 
 				const isMobileView = (this.playerHTML.getWrapperElement().closest('html.mobileview') != undefined);
 
-				audioVisu.height = (isPip) ? wrapperSize.height : wrapperSize.height;
+				audioVisu.height = wrapperSize.height;
+
 				// If not on mobile, move the visualization on top of the control bar
-				if (!isMobileView)
+				if (!isMobileView && !isPip)
 					audioVisu.height -= 63;
-				audioVisu.width = (isPip) ? wrapperSize.width : wrapperSize.width - audioVisu.height;
+				audioVisu.width = (isPip) ? wrapperSize.width : wrapperSize.width - wrapperSize.height;
+				// Move the control bar
+				if (!isPip) {
+					playerControl.style.width = (wrapperSize.width - wrapperSize.height) + 'px';
+					playerControl.style.marginLeft = wrapperSize.height + 'px';
+					playerControl.style.borderBottomLeftRadius = 0;
+				}
+
 				audioVisu.style.width = audioVisu.width + 'px';
 				audioVisu.style.height = audioVisu.height + 'px';
 				var WIDTH = audioVisu.width;
@@ -587,17 +599,16 @@ export class PeerTubeEmbed {
 					// analyser.getByteFrequencyData(dataArray);
 					ctx.fillStyle = "transparent";
 					ctx.fillRect(0, 0, WIDTH, HEIGHT);
-					const barWidth = (WIDTH / bufferLength) * 2.5;
+					const barWidth = (WIDTH / bufferLength) * 20;
 					let barHeight;
+					let barHeightPourcentage;
 					let x = 0;
+					let maxValue = 280;
 					for (let i = 0; i < bufferLength; i++) {
-						barHeight = dataArray[i];
-						if (HEIGHT > 400)
-							barHeight = barHeight * 3;
-						else if (HEIGHT > 300)
-							barHeight = barHeight * 2;
+						barHeightPourcentage = dataArray[i] / maxValue;
+						barHeight = HEIGHT * barHeightPourcentage;
 						ctx.fillStyle = `rgb(0, 166, 255)`;
-						ctx.fillRect(x, HEIGHT - barHeight / 2, barWidth, barHeight);
+						ctx.fillRect(x, HEIGHT - barHeight, barWidth, barHeight)
 						x += barWidth + 1;
 					}
 					ctx.stroke();

--- a/client/src/standalone/videos/embed.ts
+++ b/client/src/standalone/videos/embed.ts
@@ -494,6 +494,7 @@ export class PeerTubeEmbed {
 			var canvasAdded = false;
 
 			// Create a div to show the audio wallpaper
+			/*
 			const audioWallpaper = document.createElement('div')
 			audioWallpaper.className = 'vjs-audio-wallpaper';
 			const thumbnailUrl = (videoDetails.from ? 'https://' + videoDetails.from : videoDetails.host) + videoDetails.thumbnailPath;
@@ -503,6 +504,7 @@ export class PeerTubeEmbed {
 				audioWallpaper.style.width = playerWrapperSize.height + 'px';
 				audioWallpaper.style.height = playerWrapperSize.height + 'px';
 			}
+			*/
 
 			// Setup events to know when mouse is over the player
 			this.playerHTML.getWrapperElement().onmouseover = function() {
@@ -521,7 +523,7 @@ export class PeerTubeEmbed {
 				}
 			}
 			audioVisu.onclick = togglePlayerPlay;
-			audioWallpaper.onclick = togglePlayerPlay;
+			// audioWallpaper.onclick = togglePlayerPlay;
 
 			this.stopListening();
 			// Start listening to audio
@@ -533,20 +535,16 @@ export class PeerTubeEmbed {
 
 				const wrapperSize = this.playerHTML.getWrapperSize();
 
-				var playerControl: any = this.playerHTML.getWrapperElement().getElementsByClassName('vjs-control-bar')
-
-				if (!ctx || !wrapperSize || !playerControl || playerControl.length <= 0)
+				if (!ctx || !wrapperSize)
 					return
 
-				playerControl = playerControl[0];
-
-				audioWallpaper.style.width = ((isPip) ? 0 : wrapperSize.height) + 'px';
-				audioWallpaper.style.height = ((isPip) ? 0 : wrapperSize.height) + 'px';
+				// audioWallpaper.style.width = ((isPip) ? 0 : wrapperSize.height) + 'px';
+				// audioWallpaper.style.height = ((isPip) ? 0 : wrapperSize.height) + 'px';
 
 				// Add the canvas to the video player DOM if needed
 				if (!canvasAdded && playerElement.parentElement) {
 					this.playerHTML.addElementToDOM(audioVisu);
-					this.playerHTML.addElementToDOM(audioWallpaper);
+					// this.playerHTML.addElementToDOM(audioWallpaper);
 					canvasAdded = true;
 				}
 				if (!canvasAdded)
@@ -557,15 +555,12 @@ export class PeerTubeEmbed {
 				audioVisu.height = wrapperSize.height;
 
 				// If not on mobile, move the visualization on top of the control bar
+				/*
 				if (!isMobileView && !isPip)
 					audioVisu.height -= 63;
 				audioVisu.width = (isPip) ? wrapperSize.width : wrapperSize.width - wrapperSize.height;
-				// Move the control bar
-				if (!isPip) {
-					playerControl.style.width = (wrapperSize.width - wrapperSize.height) + 'px';
-					playerControl.style.marginLeft = wrapperSize.height + 'px';
-					playerControl.style.borderBottomLeftRadius = 0;
-				}
+				*/
+				audioVisu.width = wrapperSize.width;
 
 				audioVisu.style.width = audioVisu.width + 'px';
 				audioVisu.style.height = audioVisu.height + 'px';
@@ -576,9 +571,9 @@ export class PeerTubeEmbed {
 
 				// Show / hide the visualization if needed
 				const noSound = (dataArray.reduce((partialSum, value) => partialSum + value, 0) <= 0)
-				if (noSound) {
-					// const thumbnailUrl = (videoDetails.from ? 'https://' + videoDetails.from : videoDetails.host) + videoDetails.thumbnailPath;
-					// audioVisu.style.backgroundImage = 'url(' + thumbnailUrl + ')';
+				if (noSound || audioVisu['mouseOver'] == true) {
+					const thumbnailUrl = (videoDetails.from ? 'https://' + videoDetails.from : videoDetails.host) + videoDetails.thumbnailPath;
+					audioVisu.style.backgroundImage = 'url(' + thumbnailUrl + ')';
 					audioVisu.style.backgroundPosition = 'center';
 					audioVisu.style.backgroundRepeat = 'no-repeat';
 					audioVisu.style.backgroundSize = 'cover';
@@ -594,16 +589,17 @@ export class PeerTubeEmbed {
 					audioVisu.style.visibility = 'visible';
 					audioVisu.classList.remove('hide-visualization');
 					*/
+					audioVisu.style.backgroundImage = 'none';
 
 					// Bar visualization
 					// analyser.getByteFrequencyData(dataArray);
 					ctx.fillStyle = "transparent";
 					ctx.fillRect(0, 0, WIDTH, HEIGHT);
-					const barWidth = (WIDTH / bufferLength) * 20;
+					const barWidth = (WIDTH / bufferLength) * 2;
 					let barHeight;
 					let barHeightPourcentage;
 					let x = 0;
-					let maxValue = 280;
+					let maxValue = 255;
 					for (let i = 0; i < bufferLength; i++) {
 						barHeightPourcentage = dataArray[i] / maxValue;
 						barHeight = HEIGHT * barHeightPourcentage;


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Roll back the audio player style to regular height + Image is shown when the mouse over the player

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

![image](https://user-images.githubusercontent.com/3897502/216130555-7eda8b65-f584-4d6d-91ee-df71b1b91b6b.png)
![image](https://user-images.githubusercontent.com/3897502/216130587-f8c51851-b927-4841-8ce2-623167239633.png)
