### PR TITLE
fix: archive video views registration

### DIFF
--- a/client/src/standalone/videos/shared/player-manager-options.ts
+++ b/client/src/standalone/videos/shared/player-manager-options.ts
@@ -212,7 +212,7 @@ export class PlayerManagerOptions {
 
         //videoCaptions,
         inactivityTimeout: 2500,
-        videoViewUrl: this.videoFetcher.getVideoViewsUrl(video.uuid, video.host),
+        videoViewUrl: this.videoFetcher.getVideoViewsUrl(video.uuid, video.from),
 
         videoShortUUID: video.shortUUID,
         videoUUID: video.uuid,

--- a/client/src/standalone/videos/shared/video-fetcher.ts
+++ b/client/src/standalone/videos/shared/video-fetcher.ts
@@ -82,7 +82,7 @@ export class VideoFetcher {
   }
 
   getVideoViewsUrl (videoUUID: string, host: string) {
-    return this.getVideoUrl(videoUUID, host) + '/views'
+    return 'https://' + this.getVideoUrl(videoUUID, host) + '/views'
   }
 
   private loadVideoInfo (videoId: string, host: string): Promise<Response> {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
Bug with views registration on archived peertube servers. The counter is not changing, and network requests are failing. Check screenshot 1.

Deployed locally, but server is not registering yet the view. Failing with 409 error on backend so we still need some changes on peertube server side. Check screenshot 2.

[Example of such video](https://bastyon.com/index?v=2560f65439d8908ea1ec8d1c782c6d1c8037e1a4647e5dab0ccfd4798f8b0678&video=1&ref=PLZATQyqYzM6NLbH8M3LPicSU3cTAqW3SA)

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help with fixing backend

## Screenshots

##### SCREENSHOT 1
![Снимок экрана 2024-02-06 в 15 08 46](https://github.com/Chocobozzz/PeerTube/assets/22795961/464ce489-e80e-41a4-a013-c4b7bc86801f)

##### SCREENSHOT 2
![Снимок экрана 2024-02-06 в 15 08 02](https://github.com/Chocobozzz/PeerTube/assets/22795961/b3159b92-ddaf-47e6-b6cb-bc19b92134b5)
